### PR TITLE
Update to esphome version 2024.2.0

### DIFF
--- a/SW/esphome/meteo-station.yaml
+++ b/SW/esphome/meteo-station.yaml
@@ -28,7 +28,7 @@ i2c:
   id: bus_a
 
 sensor:
-  - platform: bme280
+  - platform: bme280_i2c
     temperature:
       name: "${device_name} Temperature"
       oversampling: 16x


### PR DESCRIPTION
Due to breaking change in esphome version 2024.2.0 the configuration had to be changed. 

In esphome had to be added support for the BME280 sensor over SPI. This change is a breaking change for any existing configurations using the BME280 over I2C as the platform name has been changed from `bme280` to `bme280_i2c`.